### PR TITLE
Plot joint positions

### DIFF
--- a/LEG/Leg.py
+++ b/LEG/Leg.py
@@ -21,7 +21,7 @@ class Leg:
         self.ltSquare = math.pow(self.lt, 2)
         self.servoOffset = [math.cos(self.rotation) * self.a[0], math.sin(self.rotation) * self.a[0], -self.a[1], 0]
 
-        # für Geschwindigkeitsberechnung
+        # für Geschwindigkeitsberechnung (wird nicht verwendet)
         self.lastPosition = [0, 0, 0]
 
         self.turnOffset = [n[0], n[1], n[2]]
@@ -29,10 +29,8 @@ class Leg:
         servoB = JointDrive(m[1], aOffset=self.turnOffset[1], ccw=True, prt=True, aMax=math.radians(120), aMin=math.radians(-120))
         servoC = JointDrive(m[2], aOffset=self.turnOffset[2], ccw=False, prt=True, aMax=math.radians(120), aMin=math.radians(-120))
         self.motors = [servoA, servoB, servoC]
-
-        self.motorAngles = [self.motors[0].getCurrentJointAngle(), self.motors[1].getCurrentJointAngle(), self.motors[2].getCurrentJointAngle()]
-
-    # Vorgegebene Methoden
+        
+# Vorgegebene Methoden
     def forKinAlphaJoint(self, alpha, beta, gamma):
         pos = [0, 0, 0, 1]
         pos[0] = math.cos(alpha) * (self.lt * math.cos(beta + gamma) + self.lf * math.cos(beta) + self.lc)
@@ -60,7 +58,7 @@ class Leg:
             beta = (math.pi - h2) + h1
         return (alpha, beta, gamma)
 
-    # Hilfsmethoden
+# Hilfsmethoden
     def baseCStoLegCS(self, pos=[0, 0, 0, 1]):
         noServoOffset = np.subtract(pos, self.servoOffset)
         H = np.array([
@@ -71,7 +69,8 @@ class Leg:
         pos = np.dot(H, noServoOffset)
         return pos
 
-    #Methoden für die COM-ROS Gruppe
+#Methoden für die ROB Gruppe
+    #Gibt die Fussposition im Base-KS an
     def getPosition(self):
         H = np.array([
             [math.cos(self.rotation), -math.sin(self.rotation), 0, self.offset[0]],
@@ -83,12 +82,29 @@ class Leg:
         pos = [posnp[0], posnp[1], posnp[2], 1]
         return pos
 
+    #Setzt die Fussspitze auf die gegebene Position aus dem Base-KS
     def setPosition(self, pos=[0, 0, 0, 1]):
         goalAngle = self.invKinAlphaJoint(self.baseCStoLegCS(pos))
         self.motors[0].setDesiredJointAngle([goalAngle[0]])
         self.motors[1].setDesiredJointAngle([goalAngle[1]])
         self.motors[2].setDesiredJointAngle([goalAngle[2]])
         return goalAngle
+
+    #Gibt die Gelenkposition im Base-KS an. In pos werden die Plotter-Methoden unten verwendet (z.B. getPosAlpha())
+    def getJointPosition(self, pos[0, 0, 0, 1])
+        H = np.array([
+            [math.cos(self.rotation), -math.sin(self.rotation), 0, self.offset[0]],
+            [math.sin(self.rotation), math.cos(self.rotation), 0, self.offset[1]],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]])
+        Hp = np.dot(H, pos)
+        posnp = np.add(Hp, self.servoOffset)
+        pos = [posnp[0], posnp[1], posnp[2], 1]
+        return pos
+    
+    #Gibt die aktuellen(!!!) Winkel der Gelenke an
+    def getMotorAngles(self) 
+        return [self.motors[0].getCurrentJointAngle(), self.motors[1].getCurrentJointAngle(), self.motors[2].getCurrentJointAngle()]
 
     @staticmethod
     def convert(pos, add=False):
@@ -97,26 +113,26 @@ class Leg:
         else:
             return pos[:-1]
 
-    #Zu Testzwecken im Plotter
-    def testCreateAi(self, a, alpha, d, theta):
+#Zu Testzwecken im Plotter
+    def getPosCreateAi(self, a, alpha, d, theta):
         return np.array([
             [math.cos(theta), -math.sin(theta)*math.cos(alpha), math.sin(theta)*math.sin(alpha), a*math.cos(theta)],
             [math.sin(theta), math.cos(theta)*math.cos(alpha), -math.cos(theta)*math.sin(alpha), a*math.sin(theta)],
             [0, math.sin(alpha), math.cos(alpha), d],
             [0, 0, 0, 1]])
 
-    def testPosAlpha(self):
-        A0 = self.testCreateAi(self.a[0], 0, -self.a[1], 0)
+    def getPosAlpha(self):
+        A0 = self.getPosCreateAi(self.a[0], 0, -self.a[1], 0)
         return A0
 
-    def testPosBeta(self):
-        A1 = self.testCreateAi(self.lc, math.pi/2, 0, self.motorAngles[0])
-        return np.dot(self.testPosAlpha(), A1)
+    def getPosBeta(self):
+        A1 = self.getPosCreateAi(self.lc, math.pi/2, 0, self.getMotorAngles()[0])
+        return np.dot(self.getPosAlpha(), A1)
 
-    def testPosGamma(self):
-        A2 = self.testCreateAi(self.lf, 0, 0, self.motorAngles[1])
-        return np.dot(self.testPosBeta(), A2)
+    def getPosGamma(self):
+        A2 = self.getPosCreateAi(self.lf, 0, 0, self.getMotorAngles()[1])
+        return np.dot(self.getPosBeta(), A2)
 
-    def testPosFoot(self):
-        A3 = self.testCreateAi(self.lt, 0, 0, self.motorAngles[2])
-        return np.dot(self.testPosGamma(), A3)
+    def getPosFoot(self):
+        A3 = self.getPosCreateAi(self.lt, 0, 0, self.getMotorAngles()[2])
+        return np.dot(self.getPosGamma(), A3)


### PR DESCRIPTION
-Variable motorAngles wurde nun zur Methode getMotorAngles(), um Aktualisierungen zu berücksichtigen

-getJointPosition wurde hinzugefügt. Beispielanwendung: Leg.convert(**legObject**.getJointPosition(**legObject**.getPosAlpha()) , False) 
-> AlphaPosition (x,y,z)